### PR TITLE
[쿠폰] - 도서 상세 페이지 쿠폰 전체 조회 요청 시, NullPointerException 발생 수정

### DIFF
--- a/src/main/java/com/nhnacademy/apigateway/filter/JwtAuthenticationGlobalFilter.java
+++ b/src/main/java/com/nhnacademy/apigateway/filter/JwtAuthenticationGlobalFilter.java
@@ -1,6 +1,12 @@
 package com.nhnacademy.apigateway.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nhnacademy.apigateway.application.service.TokenService;
+import com.nhnacademy.apigateway.presentation.dto.response.AuthResponse;
+import com.nhnacademy.apigateway.util.JwtUtil;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,13 +20,6 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
-import com.nhnacademy.apigateway.util.JwtUtil;
-import com.nhnacademy.apigateway.application.service.TokenService;
-import com.nhnacademy.apigateway.presentation.dto.response.AuthResponse;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import com.nhnacademy.apigateway.infrastructure.adaptor.AuthAdaptor;
 
 /**
  * JWT 인증을 처리하는 글로벌 필터 클래스입니다.

--- a/src/main/java/com/nhnacademy/apigateway/filter/JwtAuthenticationGlobalFilter.java
+++ b/src/main/java/com/nhnacademy/apigateway/filter/JwtAuthenticationGlobalFilter.java
@@ -93,8 +93,7 @@ public class JwtAuthenticationGlobalFilter implements WebFilter {
             }
         }
 
-
-        if (path.matches("/coupons") && request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION).isEmpty()) {
+        if (path.matches("/coupons") && Objects.isNull(authorizationHeader)) {
             return chain.filter(exchange);
         }
 


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 도서 상세 페이지 쿠폰 전체 조회 요청 시, NullPointerException 발생 수정했습니다.
- `도서 상세 페이지 쿠폰 전체 조회 요청`과 인증 헤더에 담긴 값을 비교해서 비회원일 경우 바로 filter.chain을 하는데 비회원은 `인증 헤더에 담긴 값` 자체가 null이라서 에러가 발생했습니다.
- null 체크 코드를 추가해서 해결했습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->